### PR TITLE
Added the possibility to pass the operator as a tuple …

### DIFF
--- a/prometheus_http_client/prometheus/client.py
+++ b/prometheus_http_client/prometheus/client.py
@@ -109,10 +109,14 @@ def _build_params(dic):
     if not isinstance(dic, dict):
         raise AssertionError("params must be dict type.")
     for k, v in dic.items():
-        if s:
-            s += ', {}="{}"'.format(k, v)
+        #if the value is a tuple then the caller likes to give also the operator like !=, =~ and so on.
+        #else the caller just likes label equals value filter
+        if isinstance(v, tuple):
+            s += '{}{}"{}", '.format(k,v[0],v[1])
         else:
-            s = '{}="{}"'.format(k, v)
+            s += '{}="{}", '.format(k, v)
+    #remove last comma
+    s = str(s[:-2])
     return '{%s}' % s
 
 


### PR DESCRIPTION
 ... with the value in the case of a filter expression. 

We use also regex in our filters. This is no issue if you are using the relabel functionality but if you like to bring in a varible into this regex in the filter then you need to give it a different operator then equals. This could be achived by modifing the client slightly.

The tuple is optional. 
The default operator remains equals.
