### PR TITLE
feat: add timeout to requests calls

### DIFF
--- a/prometheus_http_client/prometheus/client.py
+++ b/prometheus_http_client/prometheus/client.py
@@ -33,7 +33,7 @@ def _golang_parsebool(string):
 
 class Prometheus(object):
     def __init__(self, url=None, headers=None, verify_ssl=None,
-                 certs=None, timeout=10):
+                 certs=None, timeout=None):
         self.url = url or os.getenv('PROMETHEUS_URL', 'http://localhost:9090')
         if headers:
             self.headers = headers
@@ -42,8 +42,7 @@ class Prometheus(object):
             if self.headers:
                 self.headers = json.loads(self.headers)
 
-        if timeout:
-            self.timeout = timeout
+        self.timeout = float(os.getenv('PROMETHEUS_TIMEOUT', timeout))
 
         self.step_size = 257.142857143
 
@@ -61,8 +60,8 @@ class Prometheus(object):
 
         self.certs = certs
 
-        if os.getenv('PROMETHEUS_CERT', None)
-            and os.getenv('PROMETHEUS_KEY', None):
+        if (os.getenv('PROMETHEUS_CERT', None)
+            and os.getenv('PROMETHEUS_KEY', None)):
             self.certs = (os.getenv('PROMETHEUS_CERT', None),
                 os.getenv('PROMETHEUS_KEY', None))
 

--- a/prometheus_http_client/prometheus/client.py
+++ b/prometheus_http_client/prometheus/client.py
@@ -33,7 +33,7 @@ def _golang_parsebool(string):
 
 class Prometheus(object):
     def __init__(self, url=None, headers=None, verify_ssl=None,
-                 certs=None):
+                 certs=None, timeout=10):
         self.url = url or os.getenv('PROMETHEUS_URL', 'http://localhost:9090')
         if headers:
             self.headers = headers
@@ -41,6 +41,10 @@ class Prometheus(object):
             self.headers = os.getenv('PROMETHEUS_HEAD', None)
             if self.headers:
                 self.headers = json.loads(self.headers)
+
+        if timeout:
+            self.timeout = timeout
+
         self.step_size = 257.142857143
 
         if verify_ssl is not None:
@@ -57,7 +61,7 @@ class Prometheus(object):
 
         self.certs = certs
 
-        if os.getenv('PROMETHEUS_CERT', None) 
+        if os.getenv('PROMETHEUS_CERT', None)
             and os.getenv('PROMETHEUS_KEY', None):
             self.certs = (os.getenv('PROMETHEUS_CERT', None),
                 os.getenv('PROMETHEUS_KEY', None))
@@ -155,7 +159,7 @@ def _build_params(dic):
         # if the value is a tuple then the caller likes to give also the operator like !=, =~ and so on.
         # else the caller just likes label equals value filter
         if isinstance(v, tuple):
-            s += '{}{}"{}", '.format(k,v[0],v[1])
+            s += '{}{}"{}", '.format(k, v[0], v[1])
         else:
             s += '{}="{}", '.format(k, v)
     # remove last comma

--- a/prometheus_http_client/provider/__init__.py
+++ b/prometheus_http_client/provider/__init__.py
@@ -41,7 +41,8 @@ def _q(self, **kwargs):
         params={'query': kwargs.get('metric'), 'time': kwargs.get('time', time.time())},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 
 @check_params(['metric', 'start', 'end'])
@@ -55,7 +56,8 @@ def _qr(self, **kwargs):
             'step': kwargs.get('step', self.get_step(kwargs.get('start'), kwargs.get('end')))},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 
 def _t(self):
@@ -63,7 +65,8 @@ def _t(self):
         url=self.url.rstrip('/') + '/api/v1/targets',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 
 def _s(self, matches):
@@ -78,7 +81,8 @@ def _s(self, matches):
         url=url,
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 def _r(self, **kwargs):
     """ type: alert|record
@@ -90,21 +94,24 @@ def _r(self, **kwargs):
             'type': kwargs.get('type')},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 def _a(self):
     return requests.get(
         url=self.url.rstrip('/') + '/api/v1/alerts',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 def _am(self):
     return requests.get(
         url=self.url.rstrip('/') + '/api/v1/alertmanagers',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 
 def _lv(self, label):
@@ -112,7 +119,8 @@ def _lv(self, label):
         url=self.url.rstrip('/') + '/api/v1/label/{}/values'.format(label),
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs).text
+        certs=self.certs,
+        timeout=self.timeout).text
 
 
 _dic = {
@@ -121,8 +129,8 @@ _dic = {
     'query_rang': _qr,
     'targets': _t,
     'series': _s,
-    'rules':_r,
-    'alerts':_a,
+    'rules': _r,
+    'alerts': _a,
     'alert_managers': _am,
     'label_values': _lv
 }

--- a/prometheus_http_client/provider/__init__.py
+++ b/prometheus_http_client/provider/__init__.py
@@ -41,7 +41,7 @@ def _q(self, **kwargs):
         params={'query': kwargs.get('metric'), 'time': kwargs.get('time', time.time())},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 
@@ -56,7 +56,7 @@ def _qr(self, **kwargs):
             'step': kwargs.get('step', self.get_step(kwargs.get('start'), kwargs.get('end')))},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 
@@ -65,7 +65,7 @@ def _t(self):
         url=self.url.rstrip('/') + '/api/v1/targets',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 
@@ -81,7 +81,7 @@ def _s(self, matches):
         url=url,
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 def _r(self, **kwargs):
@@ -94,7 +94,7 @@ def _r(self, **kwargs):
             'type': kwargs.get('type')},
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 def _a(self):
@@ -102,7 +102,7 @@ def _a(self):
         url=self.url.rstrip('/') + '/api/v1/alerts',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 def _am(self):
@@ -110,7 +110,7 @@ def _am(self):
         url=self.url.rstrip('/') + '/api/v1/alertmanagers',
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 
@@ -119,7 +119,7 @@ def _lv(self, label):
         url=self.url.rstrip('/') + '/api/v1/label/{}/values'.format(label),
         headers=self.headers,
         verify=self.verify_ssl,
-        certs=self.certs,
+        cert=self.certs,
         timeout=self.timeout).text
 
 


### PR DESCRIPTION
Hello,

I noticed the Python `requests` calls don't have any timeout and therefore hang for ever in case prometheus api is not responding.

This PR lets the user specify or not a custom timeout for prometheus api calls. 

More info about `requests` timeout [here](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts)